### PR TITLE
[COOK-4197] Don't force 7-zip home by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,4 +28,4 @@ else
   default['7-zip']['package_name'] = "7-Zip 9.22"
 end
 
-default['7-zip']['home']    = "#{ENV['SYSTEMDRIVE']}\\7-zip"
+default['7-zip']['home']    = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,11 +21,11 @@
 windows_package node['7-zip']['package_name'] do
   source node['7-zip']['url']
   checksum node['7-zip']['checksum']
-  options "INSTALLDIR=\"#{node['7-zip']['home']}\""
+  options "INSTALLDIR=\"#{node['7-zip']['home']}\"" if node['7-zip']['home']
   action :install
 end
 
 # update path
 windows_path node['7-zip']['home'] do
   action :add
-end
+end if node['7-zip']['home']


### PR DESCRIPTION
- attribute node['7-zip']['home'] defaults to nil
- set INSTALL_DIR and PATH only if the home is specified
  otherwise just install 7-zip by default
